### PR TITLE
Implement GET /organizations/<slug> API plus other minor improvements 

### DIFF
--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -19,6 +19,7 @@ type BuildsService struct {
 type Build struct {
 	ID          *string           `json:"id,omitempty"`
 	URL         *string           `json:"url,omitempty"`
+	WebURL      *string           `json:"web_url,omitempty"`
 	Number      *int              `json:"number,omitempty"`
 	State       *string           `json:"state,omitempty"`
 	Message     *string           `json:"message,omitempty"`

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -93,7 +93,7 @@ func (as *BuildsService) Get(org string, project string, id string) (*Build, *Re
 
 // List the builds for the current user.
 //
-// buildkite API docs: https://buildkite.com/docs/api/organizations#list-organizations
+// buildkite API docs: https://buildkite.com/docs/api/builds#list-all-builds
 func (bs *BuildsService) List(opt *BuildsListOptions) ([]Build, *Response, error) {
 	var u string
 

--- a/buildkite/organizations.go
+++ b/buildkite/organizations.go
@@ -60,3 +60,24 @@ func (os *OrganizationsService) List(opt *OrganizationListOptions) ([]Organizati
 
 	return *orgs, resp, err
 }
+
+// Get fetches an organization
+//
+// buildkite API docs: https://buildkite.com/docs/api/organizations#get-an-organization
+func (os *OrganizationsService) Get(slug string) (*Organization, *Response, error) {
+
+	u := fmt.Sprintf("v1/organizations/%s", slug)
+
+	req, err := os.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	organization := new(Organization)
+	resp, err := os.client.Do(req, organization)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return organization, resp, err
+}

--- a/buildkite/organizations.go
+++ b/buildkite/organizations.go
@@ -19,6 +19,7 @@ type OrganizationsService struct {
 type Organization struct {
 	ID          *string    `json:"id,omitempty"`
 	URL         *string    `json:"url,omitempty"`
+	WebURL      *string    `json:"web_url,omitempty"`
 	Name        *string    `json:"name,omitempty"`
 	Slug        *string    `json:"slug,omitempty"`
 	Repository  *string    `json:"repository,omitempty"`

--- a/buildkite/organizations_test.go
+++ b/buildkite/organizations_test.go
@@ -26,3 +26,23 @@ func TestOrganizationsService_List(t *testing.T) {
 		t.Errorf("Organizations.List returned %+v, want %+v", orgs, want)
 	}
 }
+
+func TestOrganizationsService_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v1/organizations/babelstoemp", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{"id":"123"}`)
+	})
+
+	org, _, err := client.Organizations.Get("babelstoemp")
+	if err != nil {
+		t.Errorf("Organizations.Get returned error: %v", err)
+	}
+
+	want := &Organization{ID: String("123")}
+	if !reflect.DeepEqual(org, want) {
+		t.Errorf("Organizations.Get returned %+v, want %+v", org, want)
+	}
+}


### PR DESCRIPTION
- Implement https://buildkite.com/docs/api/organizations#get-an-organization
- Add missing WebURL fields to Build and Organisation structs
- Fix misleading comment